### PR TITLE
[chrome.angle] Force Pure RISCV64 Support on Android

### DIFF
--- a/android/angle_apk.gni
+++ b/android/angle_apk.gni
@@ -46,14 +46,14 @@ if (enable_java_templates) {
       deps = [ ":${invoker.package_name}_assets" ]
       if (symbol_level != 0) {
         deps += [ ":compressed_symbols" ]
-        if (android_64bit_target_cpu) {
+        if (android_64bit_target_cpu && defined(android_secondary_abi_toolchain)) {
           deps += [ ":compressed_symbols($android_secondary_abi_toolchain)" ]
         }
       }
 
       uncompress_shared_libraries = true
 
-      if (android_64bit_target_cpu) {
+      if (android_64bit_target_cpu && defined(android_secondary_abi_toolchain)) {
         if (symbol_level == 0) {
           secondary_abi_shared_libraries = []
           foreach(_library, angle_libraries) {


### PR DESCRIPTION
Utilize the definition of skip_secondary_abi_for_cq and android_secondary_abi_toolchain directly to support pure RISCV64 on Android.

Before RISCV64 introduced into Chromium, every 64-bit ARCH enables its own 32-bit support by default. 
But for RISCV, Android announced only pure 64-bit would be supported. 
So for Chromium RISCV64 on Android, one proposed solution based on the commit is to skip the legacy check logic for its 32-bit ABI.