### PR TITLE
[chrome.angle] catch up with upstream.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ The Khronos Group, Inc.
 Numfum GmbH
 Yandex LLC
 Rive
+Institute of Software, Chinese Academy of Sciences
 
 Jacek Caban
 Mark Callow
@@ -79,3 +80,4 @@ SeongHwan Park
 Xiaopeng Li
 Akihiko Odaki
 Ho Cheung
+Tao Wang

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -232,3 +232,6 @@ Yandex LLC
 
 Rive
  Chris Dalton
+
+Institute of Software, Chinese Academy of Sciences
+ Wang Chen

--- a/android/angle_apk.gni
+++ b/android/angle_apk.gni
@@ -46,12 +46,14 @@ if (enable_java_templates) {
       deps = [ ":${invoker.package_name}_assets" ]
       if (symbol_level != 0) {
         deps += [ ":compressed_symbols" ]
-        if (android_64bit_target_cpu) {
+        if (android_64bit_target_cpu &&
+            defined(android_secondary_abi_toolchain)) {
           deps += [ ":compressed_symbols($android_secondary_abi_toolchain)" ]
         }
       }
 
-      if (android_64bit_target_cpu) {
+      if (android_64bit_target_cpu &&
+          defined(android_secondary_abi_toolchain)) {
         if (symbol_level == 0) {
           secondary_abi_shared_libraries = []
           foreach(_library, angle_libraries) {

--- a/gni/angle.gni
+++ b/gni/angle.gni
@@ -107,7 +107,8 @@ declare_args() {
 
   if (current_cpu == "arm64" || current_cpu == "x64" ||
       current_cpu == "mips64el" || current_cpu == "s390x" ||
-      current_cpu == "ppc64" || current_cpu == "loong64") {
+      current_cpu == "ppc64" || current_cpu == "loong64" ||
+      current_cpu == "riscv64") {
     angle_64bit_current_cpu = true
   } else if (current_cpu == "arm" || current_cpu == "x86" ||
              current_cpu == "mipsel" || current_cpu == "s390" ||


### PR DESCRIPTION
angle 仓库的 diff 改动比较简单，和 upstream 的比对已完成，详细分析请看附件：
[diff.angle.txt](https://github.com/aosp-riscv/angle/files/11620549/diff.angle.txt)
